### PR TITLE
tests need riot develop branch to pass

### DIFF
--- a/riot/install.sh
+++ b/riot/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-RIOT_BRANCH=master
+RIOT_BRANCH=develop
 
 BASE_DIR=$(readlink -f $(dirname $0))
 if [ -d $BASE_DIR/riot-web ]; then


### PR DESCRIPTION
as setting an alias without a domain is only recently supported.