### PR TITLE
Tell synapse to require consent at registration

### DIFF
--- a/synapse/config-templates/consent/homeserver.yaml
+++ b/synapse/config-templates/consent/homeserver.yaml
@@ -674,6 +674,7 @@ user_consent:
   block_events_error: >-
     To continue using this homeserver you must review and agree to the
     terms and conditions at %(consent_uri)s
+  require_at_registration: true
 
 
 


### PR DESCRIPTION
To fix issues where the tests can't correctly test terms auth.