### PR TITLE
support writing logs to file

### DIFF
--- a/start.js
+++ b/start.js
@@ -18,6 +18,7 @@ const assert = require('assert');
 const RiotSession = require('./src/session');
 const scenario = require('./src/scenario');
 const RestSessionCreator = require('./src/rest/creator');
+const fs = require("fs");
 
 const program = require('commander');
 program
@@ -27,6 +28,7 @@ program
     .option('--slow-mo', "run tests slower to follow whats going on", false)
     .option('--dev-tools', "open chrome devtools in browser window", false)
     .option('--no-sandbox', "same as puppeteer arg", false)
+    .option('--error-log <n>', 'stdout, or a file to dump html and network logs in when the tests fail')
     .parse(process.argv);
 
 const hsUrl = 'http://localhost:5005';
@@ -67,18 +69,13 @@ async function runTests() {
     } catch(err) {
         failure = true;
         console.log('failure: ', err);
-        if (program.logs) {
-            for(let i = 0; i < sessions.length; ++i) {
-                const session = sessions[i];
-                documentHtml = await session.page.content();
-                console.log(`---------------- START OF ${session.username} LOGS ----------------`);
-                console.log('---------------- console.log output:');
-                console.log(session.consoleLogs());
-                console.log('---------------- network requests:');
-                console.log(session.networkLogs());
-                console.log('---------------- document html:');
-                console.log(documentHtml);
-                console.log(`---------------- END OF ${session.username} LOGS   ----------------`);
+        if (program.errorLog) {
+            const logs = await createLogs(sessions);
+            if (program.errorLog === "stdout") {
+                process.stdout.write(logs);
+            } else {
+                console.log(`wrote logs to "${program.errorLog}"`);
+                fs.writeFileSync(program.errorLog, logs);
             }
         }
     }
@@ -96,6 +93,23 @@ async function runTests() {
     } else {
         console.log('all tests finished successfully');
     }
+}
+
+async function createLogs(sessions) {
+    let logs = "";
+    for(let i = 0; i < sessions.length; ++i) {
+        const session = sessions[i];
+        documentHtml = await session.page.content();
+        logs = logs + `---------------- START OF ${session.username} LOGS ----------------\n`;
+        logs = logs + '\n---------------- console.log output:\n';
+        logs = logs + session.consoleLogs();
+        logs = logs + '\n---------------- network requests:\n';
+        logs = logs + session.networkLogs();
+        logs = logs + '\n---------------- document html:\n';
+        logs = logs + documentHtml;
+        logs = logs + `\n---------------- END OF ${session.username} LOGS   ----------------\n`;
+    }
+    return logs;
 }
 
 runTests().catch(function(err) {


### PR DESCRIPTION
`--no-logs` is now the default, and `--error-log` accepts stdout or a filename. Will use this to put huge log in build artefact in buildkit, so it doesn't polute the output log.