### PR TITLE
Fix synapse installation

### DIFF
--- a/synapse/install.sh
+++ b/synapse/install.sh
@@ -27,12 +27,6 @@ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python get-pip.py
 
 pip install --upgrade setuptools
-pip install matrix-synapse[resources.consent]
-python -m synapse.app.homeserver \
-    --server-name localhost \
-    --config-path homeserver.yaml \
-    --generate-config \
-    --report-stats=no
 pip install https://codeload.github.com/matrix-org/synapse/zip/$SYNAPSE_BRANCH
 # apply configuration
 pushd env/bin/
@@ -49,3 +43,5 @@ sed -i.bak "s#{{MACAROON_SECRET_KEY}}#$(uuidgen)#g" homeserver.yaml
 rm *.bak
 
 popd
+# generate signing keys for signing_key_path
+python -m synapse.app.homeserver --generate-keys --config-dir env/bin/ -c env/bin/homeserver.yaml

--- a/synapse/install.sh
+++ b/synapse/install.sh
@@ -16,11 +16,7 @@ if [ -d $BASE_DIR/$SERVER_DIR ]; then
 fi
 
 cd $BASE_DIR
-
-mkdir -p installations/
-curl https://codeload.github.com/matrix-org/synapse/zip/$SYNAPSE_BRANCH --output synapse.zip
-unzip -q synapse.zip
-mv synapse-$SYNAPSE_BRANCH $SERVER_DIR
+mkdir -p $SERVER_DIR
 cd $SERVER_DIR
 virtualenv -p python3 env
 source env/bin/activate
@@ -37,7 +33,9 @@ python -m synapse.app.homeserver \
     --config-path homeserver.yaml \
     --generate-config \
     --report-stats=no
+pip install https://codeload.github.com/matrix-org/synapse/zip/$SYNAPSE_BRANCH
 # apply configuration
+pushd env/bin/
 cp -r $BASE_DIR/config-templates/$CONFIG_TEMPLATE/. ./
 
 # Hashes used instead of slashes because we'll get a value back from $(pwd) that'll be
@@ -49,3 +47,5 @@ sed -i.bak "s#{{FORM_SECRET}}#$(uuidgen)#g" homeserver.yaml
 sed -i.bak "s#{{REGISTRATION_SHARED_SECRET}}#$(uuidgen)#g" homeserver.yaml
 sed -i.bak "s#{{MACAROON_SECRET_KEY}}#$(uuidgen)#g" homeserver.yaml
 rm *.bak
+
+popd

--- a/synapse/start.sh
+++ b/synapse/start.sh
@@ -3,8 +3,8 @@ set -e
 
 BASE_DIR=$(cd $(dirname $0) && pwd)
 cd $BASE_DIR
-cd installations/consent
-source env/bin/activate
+cd installations/consent/env/bin/
+source activate
 LOGFILE=$(mktemp)
 echo "Synapse log file at $LOGFILE"
 ./synctl start 2> $LOGFILE

--- a/synapse/stop.sh
+++ b/synapse/stop.sh
@@ -3,6 +3,6 @@ set -e
 
 BASE_DIR=$(cd $(dirname $0) && pwd)
 cd $BASE_DIR
-cd installations/consent
-source env/bin/activate
+cd installations/consent/env/bin/
+source activate
 ./synctl stop


### PR DESCRIPTION
The installation is failing on CI because the dependencies of synapse develop and master diverged recently.

We were installing the dependencies for synapse master through pip, and then running synapse develop downloaded from github with it.

This installs synapse develop + dependencies with pip.