### PR TITLE
Fix signup: set custom hs through advanced section, and accept IS step

### DIFF
--- a/src/usecases/signup.js
+++ b/src/usecases/signup.js
@@ -21,11 +21,15 @@ module.exports = async function signup(session, username, password, homeserver) 
     await session.goto(session.url('/#/register'));
     // change the homeserver by clicking the "Change" link.
     if (homeserver) {
-        const changeServerDetailsLink = await session.query('.mx_AuthBody_editServerDetails');
-        await changeServerDetailsLink.click();
+        const advancedButton = await session.query('.mx_ServerTypeSelector_type_Advanced');
+        await advancedButton.click();
         const hsInputField = await session.query('#mx_ServerConfig_hsUrl');
         await session.replaceInputText(hsInputField, homeserver);
         const nextButton = await session.query('.mx_Login_submit');
+        // accept homeserver
+        await nextButton.click();
+        await session.delay(200);
+        // accept discovered identity server
         await nextButton.click();
     }
     //fill out form


### PR DESCRIPTION
The "Change" link doesn't seem to appear anymore on the standard registration screen, potentially having been changed in https://github.com/matrix-org/matrix-react-sdk/pull/3343.

This PR goes through the Advanced step to set a custom HS, which should be more reliable and also not depend in matrix.org responding to the well-known request.

It breaks for me locally but strangely not on CI AFAICT, but as it is more robust, it is probably a good idea to do anyway.