### PR TITLE
Revert "Revert "Fix signup: set custom hs through advanced section, and accept IS step""

### DIFF
--- a/src/usecases/signup.js
+++ b/src/usecases/signup.js
@@ -21,11 +21,15 @@ module.exports = async function signup(session, username, password, homeserver) 
     await session.goto(session.url('/#/register'));
     // change the homeserver by clicking the "Change" link.
     if (homeserver) {
-        const changeServerDetailsLink = await session.query('.mx_AuthBody_editServerDetails');
-        await changeServerDetailsLink.click();
+        const advancedButton = await session.query('.mx_ServerTypeSelector_type_Advanced');
+        await advancedButton.click();
         const hsInputField = await session.query('#mx_ServerConfig_hsUrl');
         await session.replaceInputText(hsInputField, homeserver);
         const nextButton = await session.query('.mx_Login_submit');
+        // accept homeserver
+        await nextButton.click();
+        await session.delay(200);
+        // accept discovered identity server
         await nextButton.click();
         await session.query('.mx_ServerConfig_identityServer_shown');
         await nextButton.click();


### PR DESCRIPTION
Reverts matrix-org/matrix-react-end-to-end-tests#58

The fixes in #60 hopefully will address the error CI gave when merging this yesterday. Also, I don't understand at all how this can currently work on CI as the FREE server section is the default one and there is no "Change" server button shown there.